### PR TITLE
feat: expose compareVersion()

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,12 @@ An async variant of [`createReadonlyStore()`](#createReadonlyStore).
 
 An variant of [`initializeAsyncStore()`](#initializeAsyncStore) for `ReadonlyStore`.
 
+### compareVersion()
+
+Type: `(a: StoreVersion, b: StoreVersion) => number`
+
+Helper utility function to compare versions when implementing [`StoreOptions#initializer()`](#StoreOptionsinitializer).
+
 ## Bundling
 
 If your library will be a standalone bundle, make sure to exclude [global-store].

--- a/src/compareVersion.ts
+++ b/src/compareVersion.ts
@@ -1,0 +1,14 @@
+import { StoreVersion } from './types';
+
+export function compareVersion(a: StoreVersion, b: StoreVersion) {
+  const v1 = toVersionArray(a)
+  const v2 = toVersionArray(b)
+  return v1[0] !== v2[0] ? v1[0] - v2[0] :
+    v1[1] !== v2[1] ? v1[1] - v2[1] :
+      v1[2] - v2[2]
+}
+
+function toVersionArray(v: StoreVersion) {
+  return typeof v === 'number' ? [0, 0, v] :
+    v.split('.').map(v => Number.parseInt(v, 10))
+}

--- a/src/createAsyncReadonlyStore.spec.ts
+++ b/src/createAsyncReadonlyStore.spec.ts
@@ -8,7 +8,7 @@ test('calling initializeAsyncReadonlyStore() with no createAsyncReadonlyStore() 
 test('init single store with key', async () => {
   const moduleName = 'module-one-store-init-with-key'
   const key = '6e9dec9c-db22-4bbd-a088-ce734e34b5fd'
-  const p = createAsyncReadonlyStore(moduleName, key, 0, () => ({ a: 1 }))
+  const p = createAsyncReadonlyStore({ moduleName, key, version: 0, initializer: () => ({ a: 1 }) })
 
   initializeAsyncReadonlyStore(moduleName, key)
 
@@ -20,7 +20,7 @@ test('init single store with key', async () => {
 test('init single store without key', async () => {
   const moduleName = 'module-one-store-init-without-key'
   const key = '720d0a3b-a301-4c34-9fd9-41bb7510a5f9'
-  const p = createAsyncReadonlyStore(moduleName, key, 0, () => ({ a: 1 }))
+  const p = createAsyncReadonlyStore({ moduleName, key, version: 0, initializer: () => ({ a: 1 }) })
 
   initializeAsyncReadonlyStore(moduleName)
 
@@ -32,8 +32,8 @@ test('init single store without key', async () => {
 test('init multiple createAsynStore calls with key', async () => {
   const moduleName = 'module-multi-stores-init-with-key'
   const key = '4f9a6b0c-8756-4c5b-9e98-030b1f973dbd'
-  const p1 = createAsyncReadonlyStore(moduleName, key, 0, () => ({ a: 1 }))
-  const p2 = createAsyncReadonlyStore(moduleName, key, 0, () => ({ a: 1 }))
+  const p1 = createAsyncReadonlyStore({ moduleName, key, version: 0, initializer: () => ({ a: 1 }) })
+  const p2 = createAsyncReadonlyStore({ moduleName, key, version: 0, initializer: () => ({ a: 1 }) })
 
   initializeAsyncReadonlyStore(moduleName, key)
 
@@ -49,8 +49,8 @@ test('init multiple createAsynStore calls with key', async () => {
 
 test('init multiple stores in the same module without key', async () => {
   const moduleName = 'module-multi-stores-init-without-key'
-  const p1 = createAsyncReadonlyStore(moduleName, '4f9a6b0c-8756-4c5b-9e98-030b1f973dbd', 0, () => ({ a: 1 }))
-  const p2 = createAsyncReadonlyStore(moduleName, '3856d28c-5a8e-4edc-9ec4-6b777dbf87cb', 0, () => ({ b: 2 }))
+  const p1 = createAsyncReadonlyStore({ moduleName, key: '4f9a6b0c-8756-4c5b-9e98-030b1f973dbd', version: 0, initializer: () => ({ a: 1 }) })
+  const p2 = createAsyncReadonlyStore({ moduleName, key: '3856d28c-5a8e-4edc-9ec4-6b777dbf87cb', version: 0, initializer: () => ({ b: 2 }) })
 
   initializeAsyncReadonlyStore(moduleName)
 
@@ -65,15 +65,19 @@ test('init stores with different numeric versions is ordered by version', async 
   const o = new AssertOrder(2)
   const moduleName = 'num-version'
   const key = '2197e51e-8d14-4706-8f4f-f1beacb5a388'
-  const p1 = createAsyncReadonlyStore(moduleName, key, 1, (prev) => {
-    expect(prev).toEqual({})
-    o.once(1)
-    return { a: 1 }
+  const p1 = createAsyncReadonlyStore({
+    moduleName, key, version: 1, initializer: (prev) => {
+      expect(prev).toEqual({});
+      o.once(1);
+      return { a: 1 };
+    }
   })
-  const p2 = createAsyncReadonlyStore(moduleName, key, 3, (prev) => {
-    expect(prev).toEqual({ a: 1 })
-    o.once(2)
-    return { ...prev, b: 2 }
+  const p2 = createAsyncReadonlyStore({
+    moduleName, key, version: 3, initializer: (prev) => {
+      expect(prev).toEqual({ a: 1 });
+      o.once(2);
+      return { ...prev, b: 2 };
+    }
   })
 
   initializeAsyncReadonlyStore(moduleName)
@@ -93,14 +97,14 @@ test('init stores with different string versions is ordered by version', async (
   const key = '9fda28d3-8478-417f-b27d-f28b7c5fc93f'
 
   const promises = [
-    createAsyncReadonlyStore(moduleName, key, '0.0.0', () => { o.once(1); return { a: 1 } }),
-    createAsyncReadonlyStore(moduleName, key, '0.0.1', () => { o.once(2); return { a: 1 } }),
-    createAsyncReadonlyStore(moduleName, key, '0.1.0', () => { o.once(3); return { a: 1 } }),
-    createAsyncReadonlyStore(moduleName, key, '0.1.1', () => { o.once(4); return { a: 1 } }),
-    createAsyncReadonlyStore(moduleName, key, '1.0.0', () => { o.once(5); return { a: 1 } }),
-    createAsyncReadonlyStore(moduleName, key, '1.1.0', () => { o.once(6); return { a: 1 } }),
-    createAsyncReadonlyStore(moduleName, key, '1.1.1', () => { o.once(7); return { a: 1 } }),
-    createAsyncReadonlyStore(moduleName, key, '2.0.0', () => { o.once(8); return { a: 1 } })
+    createAsyncReadonlyStore({ moduleName, key, version: '0.0.0', initializer: () => { o.once(1); return { a: 1 }; } }),
+    createAsyncReadonlyStore({ moduleName, key, version: '0.0.1', initializer: () => { o.once(2); return { a: 1 }; } }),
+    createAsyncReadonlyStore({ moduleName, key, version: '0.1.0', initializer: () => { o.once(3); return { a: 1 }; } }),
+    createAsyncReadonlyStore({ moduleName, key, version: '0.1.1', initializer: () => { o.once(4); return { a: 1 }; } }),
+    createAsyncReadonlyStore({ moduleName, key, version: '1.0.0', initializer: () => { o.once(5); return { a: 1 }; } }),
+    createAsyncReadonlyStore({ moduleName, key, version: '1.1.0', initializer: () => { o.once(6); return { a: 1 }; } }),
+    createAsyncReadonlyStore({ moduleName, key, version: '1.1.1', initializer: () => { o.once(7); return { a: 1 }; } }),
+    createAsyncReadonlyStore({ moduleName, key, version: '2.0.0', initializer: () => { o.once(8); return { a: 1 }; } })
   ]
 
   initializeAsyncReadonlyStore(moduleName)
@@ -116,10 +120,10 @@ test('number version is compared to the patch value of string version', async ()
   const key = '9fda28d3-8478-417f-b27d-f28b7c5fc93f'
 
   const promises = [
-    createAsyncReadonlyStore(moduleName, key, 1, () => { o.once(1); return { a: 1 } }),
-    createAsyncReadonlyStore(moduleName, key, '0.0.2', () => { o.once(2); return { a: 1 } }),
-    createAsyncReadonlyStore(moduleName, key, 3, () => { o.once(3); return { a: 1 } }),
-    createAsyncReadonlyStore(moduleName, key, '0.1.0', () => { o.once(4); return { a: 1 } })
+    createAsyncReadonlyStore({ moduleName, key, version: 1, initializer: () => { o.once(1); return { a: 1 }; } }),
+    createAsyncReadonlyStore({ moduleName, key, version: '0.0.2', initializer: () => { o.once(2); return { a: 1 }; } }),
+    createAsyncReadonlyStore({ moduleName, key, version: 3, initializer: () => { o.once(3); return { a: 1 }; } }),
+    createAsyncReadonlyStore({ moduleName, key, version: '0.1.0', initializer: () => { o.once(4); return { a: 1 }; } })
   ]
 
   initializeAsyncReadonlyStore(moduleName)

--- a/src/createAsyncReadonlyStore.ts
+++ b/src/createAsyncReadonlyStore.ts
@@ -1,8 +1,9 @@
 import { createReadonlyStore, ReadonlyStore } from './createReadonlyStore';
 import { StoreOptions, StoreValue } from './types';
-import { resolveCreators, StoreCreator } from './util';
+import { StoreCreators } from './typesInternal';
+import { resolveCreators } from './util';
 
-const asyncReadonlyStoreCreators: Record<string, Record<string, Array<StoreCreator<ReadonlyStore<any>>>>> = {}
+const asyncReadonlyStoreCreators: StoreCreators<ReadonlyStore<any>> = {}
 
 /**
  * Creates a readonly store of type T.

--- a/src/createAsyncReadonlyStore.ts
+++ b/src/createAsyncReadonlyStore.ts
@@ -1,30 +1,15 @@
 import { createReadonlyStore, ReadonlyStore } from './createReadonlyStore';
-import { StoreInitializer, StoreKey, StoreValue, StoreVersion } from './types';
+import { StoreOptions, StoreValue } from './types';
 import { resolveCreators, StoreCreator } from './util';
 
-const asyncReadonlyStoreCreators: Record<string, Record<StoreKey, Array<StoreCreator<ReadonlyStore<any>>>>> = {}
+const asyncReadonlyStoreCreators: Record<string, Record<string, Array<StoreCreator<ReadonlyStore<any>>>>> = {}
 
 /**
  * Creates a readonly store of type T.
- * @param moduleName Name of your module. This will be used during reporting.
- * @param key Specific key of the store scoped to your module. This will not appear in reporting.
- * You can use `Symbol.for(<some key>)` to make the store accessible accross service workers and iframes.
- *
- * It is recommend that the key contains the purpose as well as a random value such as GUID.
- * e.g. `some-purpose:c0574313-5f6c-4c02-a875-ad793d47b695`
- * This key should not change across versions.
- * @param version Version of the store. It can be numeric or string in the format of "major.minor.patch".
- * No other string format is accepted.
- * When it is numeric, it is compare to the patch number of the string version,
- * if there is a mix of number and string versions.
- * @param initializer Initializing function for the store.
+ * https://github.com/unional/global-store#createAsyncReadonlyStore
  */
 export function createAsyncReadonlyStore<T extends StoreValue>(
-  moduleName: string,
-  key: StoreKey,
-  version: StoreVersion,
-  initializer: StoreInitializer<T>
-): Promise<ReadonlyStore<T>> {
+  { moduleName, key, version, initializer }: StoreOptions<T>): Promise<ReadonlyStore<T>> {
   return new Promise(resolve => {
     const creatorsOfModules = asyncReadonlyStoreCreators[moduleName] = asyncReadonlyStoreCreators[moduleName] || {}
     const storeCreators = creatorsOfModules[key as any] = creatorsOfModules[key as any] || []
@@ -34,8 +19,9 @@ export function createAsyncReadonlyStore<T extends StoreValue>(
 
 /**
  * Initializes the stores for `createAsyncReadonlyStore()`.
+ * https://github.com/unional/global-store#initializeAsyncReadonlyStore
  */
-export function initializeAsyncReadonlyStore(moduleName: string, key?: StoreKey) {
+export function initializeAsyncReadonlyStore(moduleName: string, key?: string) {
   const creatorsOfModules = asyncReadonlyStoreCreators[moduleName]
   if (!creatorsOfModules) return
 

--- a/src/createAsyncStore.spec.ts
+++ b/src/createAsyncStore.spec.ts
@@ -8,7 +8,7 @@ test('calling initializeAsyncStore() with no createAsyncStore() call does nothin
 test('init single store with key', async () => {
   const moduleName = 'module-one-store-init-with-key'
   const key = '6e9dec9c-db22-4bbd-a088-ce734e34b5fd'
-  const p = createAsyncStore(moduleName, key, 0, () => ({ a: 1 }))
+  const p = createAsyncStore({ moduleName, key, version: 0, initializer: () => ({ a: 1 }) })
 
   initializeAsyncStore(moduleName, key)
 
@@ -20,7 +20,7 @@ test('init single store with key', async () => {
 test('init single store without key', async () => {
   const moduleName = 'module-one-store-init-without-key'
   const key = '720d0a3b-a301-4c34-9fd9-41bb7510a5f9'
-  const p = createAsyncStore(moduleName, key, 0, () => ({ a: 1 }))
+  const p = createAsyncStore({ moduleName, key, version: 0, initializer: () => ({ a: 1 }) })
 
   initializeAsyncStore(moduleName)
 
@@ -32,8 +32,8 @@ test('init single store without key', async () => {
 test('init multiple createAsynStore calls with key', async () => {
   const moduleName = 'module-multi-stores-init-with-key'
   const key = '4f9a6b0c-8756-4c5b-9e98-030b1f973dbd'
-  const p1 = createAsyncStore(moduleName, key, 0, () => ({ a: 1 }))
-  const p2 = createAsyncStore(moduleName, key, 0, () => ({ a: 1 }))
+  const p1 = createAsyncStore({ moduleName, key, version: 0, initializer: () => ({ a: 1 }) })
+  const p2 = createAsyncStore({ moduleName, key, version: 0, initializer: () => ({ a: 1 }) })
 
   initializeAsyncStore(moduleName, key)
 
@@ -49,8 +49,8 @@ test('init multiple createAsynStore calls with key', async () => {
 
 test('init multiple stores in the same module without key', async () => {
   const moduleName = 'module-multi-stores-init-without-key'
-  const p1 = createAsyncStore(moduleName, '4f9a6b0c-8756-4c5b-9e98-030b1f973dbd', 0, () => ({ a: 1 }))
-  const p2 = createAsyncStore(moduleName, '3856d28c-5a8e-4edc-9ec4-6b777dbf87cb', 0, () => ({ b: 2 }))
+  const p1 = createAsyncStore({ moduleName, key: '4f9a6b0c-8756-4c5b-9e98-030b1f973dbd', version: 0, initializer: () => ({ a: 1 }) })
+  const p2 = createAsyncStore({ moduleName, key: '3856d28c-5a8e-4edc-9ec4-6b777dbf87cb', version: 0, initializer: () => ({ b: 2 }) })
 
   initializeAsyncStore(moduleName)
 
@@ -65,15 +65,19 @@ test('init stores with different numeric versions is ordered by version', async 
   const o = new AssertOrder(2)
   const moduleName = 'num-version'
   const key = '2197e51e-8d14-4706-8f4f-f1beacb5a388'
-  const p1 = createAsyncStore(moduleName, key, 1, (prev) => {
-    expect(prev).toEqual({})
-    o.once(1)
-    return { a: 1 }
+  const p1 = createAsyncStore({
+    moduleName, key, version: 1, initializer: (prev) => {
+      expect(prev).toEqual({});
+      o.once(1);
+      return { a: 1 };
+    }
   })
-  const p2 = createAsyncStore(moduleName, key, 3, (prev) => {
-    expect(prev).toEqual({ a: 1 })
-    o.once(2)
-    return { ...prev, b: 2 }
+  const p2 = createAsyncStore({
+    moduleName, key, version: 3, initializer: (prev) => {
+      expect(prev).toEqual({ a: 1 });
+      o.once(2);
+      return { ...prev, b: 2 };
+    }
   })
 
   initializeAsyncStore(moduleName)
@@ -93,14 +97,14 @@ test('init stores with different string versions is ordered by version', async (
   const key = '9fda28d3-8478-417f-b27d-f28b7c5fc93f'
 
   const promises = [
-    createAsyncStore(moduleName, key, '1.0.0', () => { o.once(5); return { a: 1 } }),
-    createAsyncStore(moduleName, key, '1.1.0', () => { o.once(6); return { a: 1 } }),
-    createAsyncStore(moduleName, key, '0.0.0', () => { o.once(1); return { a: 1 } }),
-    createAsyncStore(moduleName, key, '0.0.1', () => { o.once(2); return { a: 1 } }),
-    createAsyncStore(moduleName, key, '0.1.0', () => { o.once(3); return { a: 1 } }),
-    createAsyncStore(moduleName, key, '0.1.1', () => { o.once(4); return { a: 1 } }),
-    createAsyncStore(moduleName, key, '1.1.1', () => { o.once(7); return { a: 1 } }),
-    createAsyncStore(moduleName, key, '2.0.0', () => { o.once(8); return { a: 1 } })
+    createAsyncStore({ moduleName, key, version: '1.0.0', initializer: () => { o.once(5); return { a: 1 }; } }),
+    createAsyncStore({ moduleName, key, version: '1.1.0', initializer: () => { o.once(6); return { a: 1 }; } }),
+    createAsyncStore({ moduleName, key, version: '0.0.0', initializer: () => { o.once(1); return { a: 1 }; } }),
+    createAsyncStore({ moduleName, key, version: '0.0.1', initializer: () => { o.once(2); return { a: 1 }; } }),
+    createAsyncStore({ moduleName, key, version: '0.1.0', initializer: () => { o.once(3); return { a: 1 }; } }),
+    createAsyncStore({ moduleName, key, version: '0.1.1', initializer: () => { o.once(4); return { a: 1 }; } }),
+    createAsyncStore({ moduleName, key, version: '1.1.1', initializer: () => { o.once(7); return { a: 1 }; } }),
+    createAsyncStore({ moduleName, key, version: '2.0.0', initializer: () => { o.once(8); return { a: 1 }; } })
   ]
 
   initializeAsyncStore(moduleName)
@@ -116,10 +120,10 @@ test('number version is compared to the patch value of string version', async ()
   const key = '9fda28d3-8478-417f-b27d-f28b7c5fc93f'
 
   const promises = [
-    createAsyncStore(moduleName, key, 1, () => { o.once(1); return { a: 1 } }),
-    createAsyncStore(moduleName, key, '0.0.2', () => { o.once(2); return { a: 1 } }),
-    createAsyncStore(moduleName, key, 3, () => { o.once(3); return { a: 1 } }),
-    createAsyncStore(moduleName, key, '0.1.0', () => { o.once(4); return { a: 1 } })
+    createAsyncStore({ moduleName, key, version: 1, initializer: () => { o.once(1); return { a: 1 }; } }),
+    createAsyncStore({ moduleName, key, version: '0.0.2', initializer: () => { o.once(2); return { a: 1 }; } }),
+    createAsyncStore({ moduleName, key, version: 3, initializer: () => { o.once(3); return { a: 1 }; } }),
+    createAsyncStore({ moduleName, key, version: '0.1.0', initializer: () => { o.once(4); return { a: 1 }; } })
   ]
 
   initializeAsyncStore(moduleName)

--- a/src/createAsyncStore.ts
+++ b/src/createAsyncStore.ts
@@ -1,28 +1,14 @@
 import { createStore, Store } from './createStore';
-import { StoreInitializer, StoreKey, StoreValue, StoreVersion } from './types';
+import { StoreOptions, StoreValue } from './types';
 import { resolveCreators, StoreCreator } from './util';
 
-const asyncStoreCreators: Record<string, Record<StoreKey, Array<StoreCreator<Store<any>>>>> = {}
+const asyncStoreCreators: Record<string, Record<string, Array<StoreCreator<Store<any>>>>> = {}
 
 /**
  * Creates a store of type T asychronously.
- * @param moduleName Name of your module. This will be used during reporting.
- * @param key Specific key of the store scoped to your module. This will not appear in reporting.
- * You can use `Symbol.for(<some key>)` to make the store accessible accross service workers and iframes.
- *
- * It is recommend that the key contains the purpose as well as a random value such as GUID.
- * e.g. `some-purpose:c0574313-5f6c-4c02-a875-ad793d47b695`
- * This key should not change across versions.
- * @param version Version of the store. It can be numeric or string in the format of "major.minor.patch".
- * No other string format is accepted.
- * When it is numeric, it is compare to the patch number of the string version,
- * if there is a mix of number and string versions.
- * @param initializer Initializing function for the store
+ * https://github.com/unional/global-store#createAsyncStore
  */
-export async function createAsyncStore<
-  T extends StoreValue,
-  V extends StoreVersion
->(moduleName: string, key: StoreKey, version: V, initializer: StoreInitializer<T>): Promise<Store<T>> {
+export async function createAsyncStore<T extends StoreValue>({ moduleName, key, version, initializer }: StoreOptions<T>): Promise<Store<T>> {
   return new Promise(resolve => {
     const creatorsOfModules = asyncStoreCreators[moduleName] = asyncStoreCreators[moduleName] || {}
     const storeCreators = creatorsOfModules[key as any] = creatorsOfModules[key as any] || []
@@ -32,8 +18,9 @@ export async function createAsyncStore<
 
 /**
  * Initializes the stores for `createAsyncStore()`.
+ * https://github.com/unional/global-store#initializeAsyncStore
  */
-export function initializeAsyncStore(moduleName: string, key?: StoreKey) {
+export function initializeAsyncStore(moduleName: string, key?: string) {
   const creatorsOfModules = asyncStoreCreators[moduleName]
   if (!creatorsOfModules) return
 

--- a/src/createAsyncStore.ts
+++ b/src/createAsyncStore.ts
@@ -1,8 +1,9 @@
 import { createStore, Store } from './createStore';
 import { StoreOptions, StoreValue } from './types';
-import { resolveCreators, StoreCreator } from './util';
+import { resolveCreators } from './util';
+import { StoreCreators } from './typesInternal';
 
-const asyncStoreCreators: Record<string, Record<string, Array<StoreCreator<Store<any>>>>> = {}
+const asyncStoreCreators: StoreCreators<Store<any>> = {}
 
 /**
  * Creates a store of type T asychronously.

--- a/src/createReadonlyStore.spec.ts
+++ b/src/createReadonlyStore.spec.ts
@@ -4,13 +4,10 @@ import { AccessedBeforeLock, createReadonlyStore, Prohibited } from '.';
 
 const moduleName = 'your-module-2'
 
-test('store key can be symbol', () => {
-  createReadonlyStore(moduleName, Symbol.for('symbol-key'), 0, () => ({ a: 1, b: 2 }))
-})
-
 test('create with same id will get existing store', () => {
-  const store1 = createReadonlyStore(moduleName, 'same-key', 0, () => ({ a: 1 }))
-  const store2 = createReadonlyStore(moduleName, 'same-key', 0, () => ({ a: 1 }))
+  const key = 'same-key'
+  const store1 = createReadonlyStore({ moduleName, key, version: 0, initializer: () => ({ a: 1 }) })
+  const store2 = createReadonlyStore({ moduleName, key, version: 1, initializer: () => ({ a: 1 }) })
 
   store1.disableProtection()
   store2.disableProtection()
@@ -22,13 +19,13 @@ test('create with same id will get existing store', () => {
 
 test('initializer receives empty object the first time', () => {
   let actual
-  createReadonlyStore(moduleName, 'init-receive-empty-obj', 0, previous => actual = previous)
+  createReadonlyStore({ moduleName, key: 'init-receive-empty-obj', version: 0, initializer: previous => actual = previous })
   expect(actual).toEqual({})
 })
 
 test('store is typed by the initializer', () => {
-  const store1 = createReadonlyStore(moduleName, 'typed-by-initializer', 0, () => ({ a: 1 }))
-  const store2 = createReadonlyStore(moduleName, 'typed-by-initializer', 0, prev => ({ ...prev, b: 1 }))
+  const store1 = createReadonlyStore({ moduleName, key: 'typed-by-initializer', version: 0, initializer: () => ({ a: 1 }) })
+  const store2 = createReadonlyStore({ moduleName, key: 'typed-by-initializer', version: 1, initializer: prev => ({ ...prev, b: 1 }) })
 
   store1.disableProtection()
   store2.disableProtection()
@@ -38,37 +35,43 @@ test('store is typed by the initializer', () => {
 })
 
 test('store type can be overridden', () => {
-  const store = createReadonlyStore<{ a: number | undefined }>(moduleName, 'override-type', 0, () => ({ a: undefined })).lock()
+  const store = createReadonlyStore<{ a: number | undefined }>({ moduleName, key: 'override-type', version: 0, initializer: () => ({ a: undefined }) }).lock()
   typeAssertion<number | undefined>()(store.get().a)
 })
 
 test('initializer receives the previous initial value', () => {
-  createReadonlyStore(moduleName, 'same-key', 0, () => ({ a: 1 }))
+  createReadonlyStore({ moduleName, key: 'get-prev', version: 0, initializer: () => ({ a: 1 }) })
 
   let actual
-  createReadonlyStore(moduleName, 'same-key', 0, prev => actual = prev)
+  createReadonlyStore({ moduleName, key: 'get-prev', version: 1, initializer: prev => actual = prev })
 
   expect(actual).toEqual({ a: 1 })
 })
 
 test('initialize receives the versions processed', () => {
-  createReadonlyStore(moduleName, 'init-receive-versions', 0, (_, versions) => {
-    expect(versions).toEqual([])
-    return {}
+  createReadonlyStore({
+    moduleName, key: 'init-receive-versions', version: 0, initializer: (_, versions) => {
+      expect(versions).toEqual([])
+      return {}
+    }
   })
-  createReadonlyStore(moduleName, 'init-receive-versions', 1, (_, versions) => {
-    expect(versions).toEqual([0])
-    return {}
+  createReadonlyStore({
+    moduleName, key: 'init-receive-versions', version: 1, initializer: (_, versions) => {
+      expect(versions).toEqual([0])
+      return {}
+    }
   })
-  createReadonlyStore(moduleName, 'init-receive-versions', 2, (_, versions) => {
-    expect(versions).toEqual([0, 1])
-    return {}
+  createReadonlyStore({
+    moduleName, key: 'init-receive-versions', version: 2, initializer: (_, versions) => {
+      expect(versions).toEqual([0, 1])
+      return {}
+    }
   })
 })
 
 test('call reset() on 1st store gets latest initial value', () => {
-  const store1 = createReadonlyStore(moduleName, '2nd-reset-get-1st', 0, () => ({ a: 1 }))
-  createReadonlyStore(moduleName, '2nd-reset-get-1st', 0, () => ({ a: 2, b: true }))
+  const store1 = createReadonlyStore({ moduleName, key: '2nd-reset-get-1st', version: 0, initializer: () => ({ a: 1 }) })
+  createReadonlyStore({ moduleName, key: '2nd-reset-get-1st', version: 1, initializer: () => ({ a: 2, b: true }) })
   store1.disableProtection()
 
   store1.reset()
@@ -76,17 +79,17 @@ test('call reset() on 1st store gets latest initial value', () => {
 })
 
 test('call get() on not locked store throws', () => {
-  const store = createReadonlyStore(moduleName, 'get-throws', 0, () => ({ a: 1 }))
+  const store = createReadonlyStore({ moduleName, key: 'get-throws', version: 0, initializer: () => ({ a: 1 }) })
   a.throws(() => store.get(), AccessedBeforeLock)
 })
 
 test('call openForTesting() when the store is locked will throw', () => {
-  const store = createReadonlyStore(moduleName, 'locked-test-throw', 0, () => ({ a: 1 })).lock()
+  const store = createReadonlyStore({ moduleName, key: 'locked-test-throw', version: 0, initializer: () => ({ a: 1 }) }).lock()
   a.throws(() => store.disableProtection(), Prohibited)
 })
 
 test('call lock() after openForTesting() will not lock the store', () => {
-  const store = createReadonlyStore(moduleName, 'test-lock-noop', 0, () => ({ a: 1 }))
+  const store = createReadonlyStore({ moduleName, key: 'test-lock-noop', version: 0, initializer: () => ({ a: 1 }) })
 
   store.disableProtection()
   store.lock()
@@ -94,28 +97,28 @@ test('call lock() after openForTesting() will not lock the store', () => {
 })
 
 test('can call get() after the store is locked', () => {
-  const store = createReadonlyStore(moduleName, 'locked-get', 0, () => ({ a: 1 })).lock()
+  const store = createReadonlyStore({ moduleName, key: 'locked-get', version: 0, initializer: () => ({ a: 1 }) }).lock()
   expect(store.get()).toEqual({ a: 1 })
 })
 
 test('call reset() on locked store throws', () => {
-  const store = createReadonlyStore(moduleName, 'reset-locked-throws', 0, () => ({ a: 1 })).lock()
+  const store = createReadonlyStore({ moduleName, key: 'reset-locked-throws', version: 0, initializer: () => ({ a: 1 }) }).lock()
   a.throws(() => store.reset(), Prohibited)
 })
 
 test('call lock() on locked store is no-op', () => {
-  const store = createReadonlyStore(moduleName, 'lock-on-locked', 0, () => ({})).lock()
+  const store = createReadonlyStore({ moduleName, key: 'lock-on-locked', version: 0, initializer: () => ({}) }).lock()
   store.lock()
 })
 
 describe('getWritable()', () => {
   test('throws if the store is locked', () => {
-    const store = createReadonlyStore(moduleName, 'getwritable-on-locked', 0, () => ({})).lock()
+    const store = createReadonlyStore({ moduleName, key: 'getwritable-on-locked', version: 0, initializer: () => ({}) }).lock()
     a.throws(() => store.getWritable(), Prohibited)
   })
 
   test('can be used during config to get and update the store value before the store is locked', () => {
-    const store = createReadonlyStore(moduleName, 'getwritable-on-locked', 0, () => ({ a: 1 }))
+    const store = createReadonlyStore({ moduleName, key: 'getwritable-on-locked', version: 0, initializer: () => ({ a: 1 }) })
     store.getWritable().a = 2
     store.lock()
     expect(store.get()).toEqual({ a: 2 })
@@ -123,7 +126,7 @@ describe('getWritable()', () => {
 });
 
 test('property values are frozen in a locked store', () => {
-  const store = createReadonlyStore(moduleName, 'prop-freeze', 0, () => ({ a: 1, b: true, c: 'str', d: {}, e: [] as any[] })).lock()
+  const store = createReadonlyStore({ moduleName, key: 'prop-freeze', version: 0, initializer: () => ({ a: 1, b: true, c: 'str', d: {}, e: [] as any[] }) }).lock()
 
   a.throws(() => store.get().a = 2, TypeError)
   a.throws(() => store.get().b = false, TypeError)
@@ -133,11 +136,11 @@ test('property values are frozen in a locked store', () => {
 })
 
 test('property value can be undefined', () => {
-  createReadonlyStore(moduleName, 'prop-array-freeze', 0, () => ({ und: undefined })).lock()
+  createReadonlyStore({ moduleName, key: 'prop-array-freeze', version: 0, initializer: () => ({ und: undefined }) }).lock()
 })
 
 test('array property is frozen in a locked store', () => {
-  const store = createReadonlyStore(moduleName, 'prop-array-freeze', 0, () => ({ arr: [] as any[], und: undefined })).lock()
+  const store = createReadonlyStore({ moduleName, key: 'prop-array-freeze', version: 0, initializer: () => ({ arr: [] as any[], und: undefined }) }).lock()
 
   a.throws(() => store.get().arr.push('a'), TypeError)
 })
@@ -145,13 +148,13 @@ test('array property is frozen in a locked store', () => {
 test('property can be symbol', () => {
   const sym1 = Symbol()
   const sym2 = Symbol()
-  const store = createReadonlyStore(moduleName, 'prop-array-freeze', 0, () => ({ [sym1]: undefined, [sym2]: [] as any[] })).lock()
+  const store = createReadonlyStore({ moduleName, key: 'prop-array-freeze', version: 0, initializer: () => ({ [sym1]: undefined, [sym2]: [] as any[] }) }).lock()
 
   a.throws(() => store.get()[sym2].push('a'), TypeError)
 })
 
 test('can specify finalizer during lock() to process the values', () => {
-  const store = createReadonlyStore(moduleName, 'finalizer', 0, () => ({ a: 1, b: { c: 1 }, c: ['a'] }))
+  const store = createReadonlyStore({ moduleName, key: 'finalizer', version: 0, initializer: () => ({ a: 1, b: { c: 1 }, c: ['a'] }) })
 
   store.lock({
     a: (value) => value + 1,
@@ -168,7 +171,7 @@ test('can specify finalizer during lock() to process the values', () => {
 })
 
 test('finalizer can contain properties out of the store type so it can process older version store values', () => {
-  const store = createReadonlyStore(moduleName, 'finalizer-record', 0, () => ({ a: 1 }))
+  const store = createReadonlyStore({ moduleName, key: 'finalizer-record', version: 0, initializer: () => ({ a: 1 }) })
 
   store.lock({
     a: v => v + 1,

--- a/src/createReadonlyStore.ts
+++ b/src/createReadonlyStore.ts
@@ -1,6 +1,6 @@
 import { Store } from './createStore';
 import { AccessedBeforeLock, Prohibited } from './errors';
-import { StoreInitializer, StoreKey, StoreValue, StoreVersion } from './types';
+import { StoreOptions, StoreValue } from './types';
 import { StoreId, Stores } from './typesInternal';
 import { getStore, getStoreValue, initStoreValue, resetStoreValue } from './util';
 
@@ -34,18 +34,11 @@ export type ReadonlyStore<T extends StoreValue> = Store<T> & {
 
 /**
  * Creates a readonly store of type T.
- * @param moduleName Name of your module. This will be used during reporting.
- * @param key Specific key of the store scoped to your module. This will not appear in reporting.
- * You can use `Symbol.for(<some key>)` to make the store accessible accross service workers and iframes.
- *
- * It is recommend that the key contains the purpose as well as a random value such as GUID.
- * e.g. `some-purpose:c0574313-5f6c-4c02-a875-ad793d47b695`
- * This key should not change across versions.
- * @param initializer Initializing function for the store.
+ * https://github.com/unional/global-store#createreadonlystore
  */
 export function createReadonlyStore<
   T extends StoreValue
->(moduleName: string, key: StoreKey, version: StoreVersion, initializer: StoreInitializer<T>): ReadonlyStore<T> {
+>({ moduleName, key, version, initializer }: StoreOptions<T>): ReadonlyStore<T> {
   initStoreValue(readonlyStores, { moduleName, key }, version, initializer)
   let isLocked = false
   let disabled = false

--- a/src/createStore.spec.ts
+++ b/src/createStore.spec.ts
@@ -3,76 +3,97 @@ import { createStore } from '.';
 
 const moduleName = 'your-module'
 
-test('id.key can be symbol', () => {
-  const store = createStore(moduleName, Symbol.for('symbol-key'), 0, () => ({ a: 1 }))
-  expect(store.get().a).toBe(1)
-})
-
 test('create with same id will get existing store', () => {
-  const store1 = createStore(moduleName, 'same-key', 0, () => ({ a: 1 }))
-  const store2 = createStore(moduleName, 'same-key', 0, () => ({ a: 1 }))
+  const key = 'same-key'
+  const version = 0
+  const initializer = () => ({ a: 1 })
+  const store1 = createStore({ moduleName, key, version, initializer })
+  const store2 = createStore({ moduleName, key, version, initializer })
   store1.get().a = 2
 
   expect(store2.get()).toEqual({ a: 2 })
 })
 
+test('initializer of the same version is skipped', () => {
+  const key = 'skip-same-ver-init'
+  const version = 0
+  createStore({ moduleName, key, version, initializer: () => ({ a: 1 }) })
+  createStore({ moduleName, key, version, initializer: () => { throw new Error('should not reach') } })
+})
+
 test('initializer receives empty object the first time', () => {
   let actual
-  createStore(moduleName, 'init-receive-empty-obj', 0, previous => actual = previous)
+  createStore({ moduleName, key: 'init-receive-empty-obj', version: 0, initializer: previous => actual = previous })
   expect(actual).toEqual({})
 })
 
 test('initialize receives the versions processed', () => {
-  createStore(moduleName, 'init-receive-versions', 0, (_, versions) => {
-    expect(versions).toEqual([])
-    return {}
+  const key = 'init-receive-versions'
+  createStore({
+    moduleName, key, version: 0, initializer: (_, versions) => {
+      expect(versions).toEqual([])
+      return {}
+    }
   })
-  createStore(moduleName, 'init-receive-versions', 1, (_, versions) => {
-    expect(versions).toEqual([0])
-    return {}
+  createStore({
+    moduleName, key, version: 1, initializer: (_, versions) => {
+      expect(versions).toEqual([0])
+      return {}
+    }
   })
-  createStore(moduleName, 'init-receive-versions', 2, (_, versions) => {
-    expect(versions).toEqual([0, 1])
-    return {}
+  createStore({
+    moduleName, key, version: 2, initializer: (_, versions) => {
+      expect(versions).toEqual([0, 1])
+      return {}
+    }
   })
 })
 
 test('store is typed by the initializer', () => {
-  const store1 = createStore(moduleName, 'typed-by-initializer', 0, () => ({ a: 1 }))
-  const store2 = createStore(moduleName, 'typed-by-initializer', 0, prev => ({ ...prev, b: 1 }))
+  const key = 'typed-by-initializer'
+  const store1 = createStore({
+    moduleName, key, version: 0, initializer: () => ({ a: 1 })
+  })
+  const store2 = createStore({
+    moduleName, key, version: 1, initializer: prev => ({ ...prev, b: 1 })
+  })
   assertType.isNumber(store1.get().a)
   assertType.isNumber(store2.get().b)
 })
 
 test('store type can be overridden', () => {
-  const store = createStore<{ a: number | undefined }>(moduleName, 'override-type', 0, () => ({ a: undefined }))
+  const store = createStore<{ a: number | undefined }>({
+    moduleName, key: 'override-type', version: 0, initializer: () => ({ a: undefined })
+  })
   typeAssertion<number | undefined>()(store.get().a)
 })
 
 test('initializer receives the previous initial value', () => {
-  createStore(moduleName, 'same-key', 0, () => ({ a: 1 }))
+  const key = 'init-get-prev'
+  createStore({ moduleName, key, version: 0, initializer: () => ({ a: 1 }) })
 
   let actual
-  createStore(moduleName, 'same-key', 0, prev => actual = prev)
+  createStore({ moduleName, key, version: 1, initializer: prev => actual = prev })
 
   expect(actual).toEqual({ a: 1 })
 })
 
 test('call reset() on 1st store gets latest initial value', () => {
-  const store1 = createStore(moduleName, '2nd-reset-get-1st', 0, () => ({ a: 1 }))
-  createStore(moduleName, '2nd-reset-get-1st', 0, () => ({ a: 2, b: true }))
+  const key = '2nd-reset-get-1st'
+  const store1 = createStore({ moduleName, key, version: 0, initializer: () => ({ a: 1 }) })
+  createStore({ moduleName, key, version: 1, initializer: () => ({ a: 2, b: true }) })
   store1.reset()
   expect(store1.get()).toEqual({ a: 2, b: true })
 })
 // test and get between create
 
 test('gets initial value', () => {
-  const store = createStore(moduleName, 'get-all', 0, () => ({ a: 1, b: 'b' }))
+  const store = createStore({ moduleName, key: 'get-all', version: 0, initializer: () => ({ a: 1, b: 'b' }) })
   expect(store.get()).toEqual({ a: 1, b: 'b' })
 })
 
 test('property reference are persisted', () => {
-  const store = createStore(moduleName, 'prop-ref', 0, () => ({ a: { b: 1 } }))
+  const store = createStore({ moduleName, key: 'prop-ref', version: 0, initializer: () => ({ a: { b: 1 } }) })
   const orig = store.get()
   orig.a = { b: 3 }
   const actual = store.get()

--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -1,4 +1,4 @@
-import { StoreInitializer, StoreValue, StoreVersion, StoreKey } from './types';
+import { StoreOptions, StoreValue } from './types';
 import { Stores } from './typesInternal';
 import { getStoreValue, initStoreValue, resetStoreValue } from './util';
 
@@ -18,18 +18,11 @@ const stores: Stores = {}
 
 /**
  * Creates a store of type T.
- * @param moduleName Name of your module. This will be used during reporting.
- * @param key Specific key of the store scoped to your module. This will not appear in reporting.
- * You can use `Symbol.for(<some key>)` to make the store accessible accross service workers and iframes.
- *
- * It is recommend that the key contains the purpose as well as a random value such as GUID.
- * e.g. `some-purpose:c0574313-5f6c-4c02-a875-ad793d47b695`
- * This key should not change across versions.
- * @param initializer Initializing function for the store
+ * https://github.com/unional/global-store#createstore
  */
 export function createStore<
   T extends StoreValue
->(moduleName: string, key: StoreKey, version: StoreVersion, initializer: StoreInitializer<T>): Store<T> {
+>({ moduleName, key, version, initializer }: StoreOptions<T>): Store<T> {
   initStoreValue(stores, { moduleName, key }, version, initializer)
 
   return {
@@ -37,3 +30,4 @@ export function createStore<
     reset: () => resetStoreValue(stores, { moduleName, key })
   }
 }
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * from './compareVersion';
 export * from './createAsyncReadonlyStore';
 export * from './createAsyncStore';
 export * from './createReadonlyStore';
@@ -5,4 +6,3 @@ export * from './createStore';
 export { createStore as default } from './createStore';
 export * from './errors';
 export * from './types';
-

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,16 +1,13 @@
 
+export type StoreOptions<T extends StoreValue> = {
+  moduleName: string,
+  key: string,
+  version: StoreVersion,
+  initializer: StoreInitializer<T>
+}
+
 export type StoreValue = Record<string | symbol, any>
 
 export type StoreVersion = string | number
 
-export type StoreKey = string | symbol
-
-/**
- * Function to initialize the store.
- * @param previousInitValue The initial value returned by previous call.
- * It will be an empty object if `createStore()` is called the first time.
- * @param lastProcessedVersion The version of the last initializer.
- * This is useful to figure out that information should be kept or not.
- */
 export type StoreInitializer<T extends StoreValue> = (previousInitValue: StoreValue, processedVersions: StoreVersion[]) => T
-

--- a/src/typesInternal.ts
+++ b/src/typesInternal.ts
@@ -1,19 +1,13 @@
-import { StoreKey, StoreVersion } from './types';
+import { StoreInitializer, StoreVersion } from './types';
 
-export type StoreId = {
-  /**
-   * Name of your module. This will be used during reporting.
-   */
-  moduleName: string,
-  /**
-   * Specific key of the store scoped to your module. This will not appear in reporting.
-   * You can use `Symbol.for(<some key>)` to make the store accessible accross service workers and iframes.
-   *
-   * It is recommend that the key contains the purpose as well as a random value such as GUID.
-   * e.g. `some-purpose:c0574313-5f6c-4c02-a875-ad793d47b695`
-   * This key should not change across versions.
-   */
-  key: StoreKey
-}
+export type StoreId = { moduleName: string, key: string }
 
 export type Stores = Record<StoreId['moduleName'], Record<StoreId['key'], { versions: StoreVersion[], init: any, value: any }>>
+
+export type StoreCreator<S> = {
+  version: StoreVersion,
+  resolve: (store: S) => void,
+  initializer: StoreInitializer<any>
+}
+
+export type StoreCreators<Store> = Record<StoreId['moduleName'], Record<StoreId['key'], Array<StoreCreator<Store>>>>

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,5 @@
-import { StoreInitializer, StoreValue, StoreVersion, StoreKey } from './types';
+import { compareVersion } from './compareVersion';
+import { StoreInitializer, StoreValue, StoreVersion } from './types';
 import { StoreId, Stores } from './typesInternal';
 
 export function getStoreValue(stores: Stores, id: StoreId): any {
@@ -7,8 +8,10 @@ export function getStoreValue(stores: Stores, id: StoreId): any {
 
 export function initStoreValue<T extends StoreValue>(stores: Stores, id: StoreId, version: StoreVersion, initializer: StoreInitializer<T>) {
   const store = getStore(stores, id)
-  store.init = initializer(store.init, store.versions)
-  store.versions.push(version)
+  if (!~store.versions.indexOf(version)) {
+    store.init = initializer(store.init, store.versions)
+    store.versions.push(version)
+  }
   store.value = createStoreValue(store.init)
 }
 
@@ -32,22 +35,10 @@ export type StoreCreator<S> = {
   initializer: StoreInitializer<any>
 }
 
-export function resolveCreators<S>(moduleName: string, key: StoreKey, storeCreators: Array<StoreCreator<S>>, createStore: any) {
-  sortByVersion(storeCreators).forEach(({ version, resolve, initializer }) => resolve(createStore(moduleName, key, version, initializer)))
+export function resolveCreators<S>(moduleName: string, key: string, storeCreators: Array<StoreCreator<S>>, createStore: any) {
+  sortByVersion(storeCreators).forEach(({ version, resolve, initializer }) => resolve(createStore({ moduleName, key, version, initializer })))
 }
 
 export function sortByVersion<S>(storeCreators: Array<StoreCreator<S>>) {
-  return storeCreators.sort((a, b) => compareVersion(toStringVersion(a.version), toStringVersion(b.version)))
-}
-
-function toStringVersion(v: string | number) {
-  return typeof v === 'number' ? `0.0.${v}` : v
-}
-
-export function compareVersion(a: string, b: string) {
-  const v1 = a.split('.').map(v => Number(v))
-  const v2 = b.split('.').map(v => Number(v))
-  return v1[0] !== v2[0] ? v1[0] - v2[0] :
-    v1[1] !== v2[1] ? v1[1] - v2[1] :
-      v1[2] - v2[2]
+  return storeCreators.sort((a, b) => compareVersion(a.version, b.version))
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,6 @@
 import { compareVersion } from './compareVersion';
 import { StoreInitializer, StoreValue, StoreVersion } from './types';
-import { StoreId, Stores } from './typesInternal';
+import { StoreCreator, StoreId, Stores } from './typesInternal';
 
 export function getStoreValue(stores: Stores, id: StoreId): any {
   return getStore(stores, id).value
@@ -27,12 +27,6 @@ export function getStore(stores: Stores, id: StoreId) {
 
 export function createStoreValue(initialValue: any) {
   return { ...initialValue }
-}
-
-export type StoreCreator<S> = {
-  version: StoreVersion,
-  resolve: (store: S) => void,
-  initializer: StoreInitializer<any>
 }
 
 export function resolveCreators<S>(moduleName: string, key: string, storeCreators: Array<StoreCreator<S>>, createStore: any) {


### PR DESCRIPTION
It is useful for initializer implementation.

feat: change signature to use `StoreOptions`

To make it more future proof,
reduce the change of breaking change in the future when we need to add more arguments.