### PR TITLE
fix: do not deep freeze supplied value

### DIFF
--- a/src/createStore.spec.ts
+++ b/src/createStore.spec.ts
@@ -160,4 +160,28 @@ describe('freeze store', () => {
     store.freeze()
     store.value.a[0].x = 'y'
   })
+
+  test('freeze provided value but not array property', () => {
+    const store = createStore({
+      moduleName,
+      key: 'not freeze array value',
+      version: 0,
+      initializer: () => ({ a: { b: 1 }, c: [{ x: 1 }] })
+    })
+
+    store.freeze(store.value)
+    a.throws(() => store.value.a = { b: 2 }, TypeError)
+    store.value.c.push({ x: 2 })
+  })
+  test('user can pre-freeze value', () => {
+    const store = createStore({
+      moduleName,
+      key: 'self freeze',
+      version: 0,
+      initializer: () => ({ a: { b: 1 } })
+    })
+
+    store.freeze(Object.freeze(store.value))
+
+  })
 })

--- a/src/createStore.ts
+++ b/src/createStore.ts
@@ -10,9 +10,12 @@ export type Store<T extends StoreValue> = {
   /**
    * Freezes the store value.
    * @param value Optional new store value.
+   * If supplied, this value will be freezed and used as the store value.
    * You can use this update the store value and freeze part of it.
+   * If not supplied,
+   * the original value will be freezed and its array property will also be freezed.
    */
-  freeze(value?: T): void
+  freeze(value?: { [k in keyof T]: Readonly<T[k]> }): void
   /**
    * Resets the store to its initial value.
    * You should only use this during testing.

--- a/src/util.ts
+++ b/src/util.ts
@@ -42,7 +42,9 @@ export function sortByVersion<S>(storeCreators: Array<StoreCreator<S>>) {
 
 export function freezeStoreValue(stores: Stores, id: StoreId, value?: any) {
   const store = getStore(stores, id)
-  store.value = freezeValue(value || store.value)
+  store.value = value ?
+    Object.isFrozen(value) ? value : Object.freeze(value) :
+    freezeValue(store.value)
 }
 
 function freezeValue(storeValue: StoreValue) {


### PR DESCRIPTION
This allows consumer to have more control on which part of the value should not be frozen